### PR TITLE
Adding Santiago Canyon College as an approved domain

### DIFF
--- a/lib/domains/edu/sccollege.txt
+++ b/lib/domains/edu/sccollege.txt
@@ -1,0 +1,1 @@
+Santiago Canyon College


### PR DESCRIPTION
Santiago Canyon College (https://sccollege.edu)

SCC is a community college (2 year) located in Orange County, California that include Computer Science as an "Area of Study": https://sccollege.edu/academics/areasofstudy/computerscience/SitePages/Home.aspx

 